### PR TITLE
feat: allow manual submission in JS-disabled user-agents

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,10 @@ var html = '<html>' +
   '<body onload="javascript:document.forms[0].submit()">' +
     '<form method="post" action="{ACTION}">' +
       '{INPUTS}' +
+      '<noscript>' +
+      'Your browser\'s JavaScript is disabled. Consider whitelisting this site to skip this manual step in the future.<br/>' +
+      '<button autofocus type="submit">Continue without JavaScript</button>' +
+      '</noscript>' +
     '</form>' +
   '</body>' +
 '</html>';

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -58,6 +58,7 @@ nrQ5IKXuNsQ1g9ccT5DMtZSwgDFwsHMDWMPFGax5Lw6ogjwJ4AQDrhzNCFc\
 <form method=\"post\" action=\"https://client.example.org/callback\">\
 <input type=\"hidden\" name=\"state\" value=\"DcP7csa3hMlvybERqcieLHrRzKBra\"/>\
 <input type=\"hidden\" name=\"id_token\" value=\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjEifQ.eyJzdWIiOiJqb2huIiwiYXVkIjoiZmZzMiIsImp0aSI6ImhwQUI3RDBNbEo0c2YzVFR2cllxUkIiLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0OjkwMzEiLCJpYXQiOjEzNjM5MDMxMTMsImV4cCI6MTM2MzkwMzcxMywibm9uY2UiOiIyVDFBZ2FlUlRHVE1BSnllRE1OOUlKYmdpVUciLCJhY3IiOiJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YWM6Y2xhc3NlczpQYXNzd29yZCIsImF1dGhfdGltZSI6MTM2MzkwMDg5NH0.c9emvFayy-YJnO0kxUNQqeAoYu7sjlyulRSNrru1ySZs2qwqqwwq-Qk7LFd3iGYeUWrfjZkmyXeKKs_OtZ2tI2QQqJpcfrpAuiNuEHII-_fkIufbGNT_rfHUcY3tGGKxcvZO9uvgKgX9Vs1v04UaCOUfxRjSVlumE6fWGcqXVEKhtPadj1elk3r4zkoNt9vjUQt9NGdm1OvaZ2ONprCErBbXf1eJb4NW_hnrQ5IKXuNsQ1g9ccT5DMtZSwgDFwsHMDWMPFGax5Lw6ogjwJ4AQDrhzNCFc0uVAwBBb772-86HpAkGWAKOK-wTC6ErRTcESRdNRe0iKb47XRXaoz5acA\"/>\
+<noscript>Your browser\'s JavaScript is disabled. Consider whitelisting this site to skip this manual step in the future.<br/><button autofocus type="submit">Continue without JavaScript</button></noscript>\
 </form>\
 </body>\
 </html>');
@@ -102,6 +103,7 @@ nrQ5IKXuNsQ1g9ccT5DMtZSwgDFwsHMDWMPFGax5Lw6ogjwJ4AQDrhzNCFc\
 <input type="hidden" name="state" value="&quot;&gt;&lt;/a&gt;DcP7csa3hMlvybERqcieLHrRzKBra"/>\
 <input type="hidden" name="id_token" value="&quot;&gt;&lt;/a&gt;eyJhbGciOiJSUzI1NiIsImtpZCI6IjEifQ.eyJzdWIiOiJqb2huIiw"/>\
 <input type="hidden" name="expires_in" value="86400"/>\
+<noscript>Your browser\'s JavaScript is disabled. Consider whitelisting this site to skip this manual step in the future.<br/><button autofocus type="submit">Continue without JavaScript</button></noscript>\
 </form></body></html>');
     });
   });


### PR DESCRIPTION
This PR adds `<noscript>` way to submit the rendered form to allow for, albeit degredated, way for user-agents with disabled javascript to continue with the POST to the specified redirect_uri.

No change in experience or visuals to user-agents with JS enabled.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/oauth2orize-fprm/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ make test`) executes successfully.
- [x] The automated code linting (`$ make lint`) executes successfully.
